### PR TITLE
New param for using prerelease version  of images

### DIFF
--- a/src/services/docker.registry.service.ts
+++ b/src/services/docker.registry.service.ts
@@ -5,6 +5,7 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import LRU from 'lru-cache';
 import * as semver from 'semver';
 import axios from 'axios';
+import { getYargsOption } from 'src/yargs';
 
 export enum DockerRegistry {
   query = 'onfinality/subql-query',
@@ -45,12 +46,17 @@ export class DockerRegistryService implements OnModuleInit {
     return tags;
   }
 
+  private enablePrerelease(): boolean {
+    const { argv } = getYargsOption();
+    return argv['use-prerelease'];
+  }
+
   private filterRegistryVersions(tags: string[], range: string) {
     if (!semver.validRange(range)) return tags;
 
     const result = tags
       .filter((t) => {
-        if (semver.prerelease(t)) return false;
+        if (semver.prerelease(t)) return this.enablePrerelease();
         if (semver.prerelease(semver.validRange(range))) {
           return semver.satisfies(t, range);
         } else {

--- a/src/yargs.ts
+++ b/src/yargs.ts
@@ -66,6 +66,12 @@ export function getYargsOption() {
       default: false,
       group: Groups.coordinator,
     },
+    'use-prerelease': {
+      type: 'boolean',
+      describe: 'Enable pre-release versions for the docker images',
+      default: false,
+      group: Groups.coordinator,
+    },
     'pushgateway-endpoint': {
       type: 'string',
       describe: 'Specify pushgateway endpoint',


### PR DESCRIPTION
## Changes

- Add new params `use-prerelease` to control whether using rerelease docker images of node and query service