### PR TITLE
fix send tx retry stuck issue

### DIFF
--- a/src/core/network.service.ts
+++ b/src/core/network.service.ts
@@ -125,7 +125,11 @@ export class NetworkService implements OnApplicationBootstrap {
   }
 
   @mutexPromise()
-  async sendTransaction(actionName: string, txFun: TxFun, desc = '', retries = 0) {
+  async sendTransaction(actionName: string, txFun: TxFun, desc = '') {
+    await this._sendTransaction(actionName, txFun, desc);
+  }
+
+  private async _sendTransaction(actionName: string, txFun: TxFun, desc = '', retries = 0) {
     try {
       logger.info(`${colorText(actionName)}: ${colorText('PROCESSING', TextColor.YELLOW)} ${desc}`);
 
@@ -139,7 +143,7 @@ export class NetworkService implements OnApplicationBootstrap {
     } catch (e) {
       if (retries < MAX_RETRY) {
         logger.warn(`${colorText(actionName)}: ${colorText('RETRY', TextColor.YELLOW)} ${desc}`);
-        await this.sendTransaction(actionName, txFun, desc, retries + 1);
+        await this._sendTransaction(actionName, txFun, desc, retries + 1);
       } else {
         logger.warn(e, `${colorText(actionName)}: ${colorText('FAILED', TextColor.RED)}`);
         throw e;


### PR DESCRIPTION
Before, when retry happens, it call itself. But because of `@mutexPromise`, it append itself to the promise that never resolve.

To fix it, simply break it to two functions, and avoid do recursive call on the one with `@mutexPromise`