### PR TITLE
Support publishing image to dev repo

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -1,0 +1,59 @@
+name: "Node-to-docker"
+on:
+  workflow_dispatch:
+    inputs:
+      isLatest:
+        description: 'Add latest tag'
+        default: 'false'
+        require: false
+
+jobs:
+  node-build-push-docker:
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
+          token: ${{ secrets.REPO_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: onfinality
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      ## node
+      - name: Get updated coordinator version
+        id: get-coordinator-version
+        run: |
+          sh .github/workflows/scripts/coordinatorVersion.sh
+
+      - name: Build and push
+        if: github.event.inputs.isLatest == 'false'
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          platforms: arm64,amd64
+          file: ./Dockerfile
+          tags: onfinality/subql-coordinator-dev:v${{ steps.get-coordinator-version.outputs.COORDINATOR_VERSION }}
+          build-args: RELEASE_VERSION=${{ steps.get-coordinator-version.outputs.COORDINATOR_VERSION }}
+
+      - name: Build and push
+        if: github.event.inputs.isLatest == 'true'
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          platforms: arm64,amd64
+          file: ./Dockerfile
+          tags: onfinality/subql-coordinator-dev:v${{ steps.get-coordinator-version.outputs.COORDINATOR_VERSION }},onfinality/subql-coordinator:latest
+          build-args: RELEASE_VERSION=${{ steps.get-coordinator-version.outputs.COORDINATOR_VERSION }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-prod.yml
+++ b/.github/workflows/docker-prod.yml
@@ -4,8 +4,8 @@ on:
     inputs:
       isLatest:
         description: 'Add latest tag'
-        default: 'true'
-        require: true
+        default: 'false'
+        require: false
 
 jobs:
   node-build-push-docker:


### PR DESCRIPTION
## Changes

- Rename docker pipeline to `docker-dev` and  `docker-prod`
- dev images will publish to `onfinality/subql-coordinator-dev` and prod to `onfinality/subql-coordinator`
- Don't use `latest tag` by default