### PR TITLE
Fix port issue when start indexing project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subql/indexer-coordinator",
-  "version": "1.1.4-2",
+  "version": "1.1.4-0",
   "description": "",
   "author": "SubQuery",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@subql/indexer-coordinator",
-  "version": "1.1.4-0",
+  "version": "1.1.4-2",
   "description": "",
   "author": "SubQuery",
   "license": "Apache-2.0",

--- a/src/project/port.service.ts
+++ b/src/project/port.service.ts
@@ -30,7 +30,12 @@ export class PortService {
     });
   }
 
-  async getAvailablePort(): Promise<number> {
+  getAvailablePort(): number {
+    return 3100;
+  }
+
+  // FIXME: This service has issue to find the real free port on host service
+  async _getAvailablePort(): Promise<number> {
     let port: number;
     let startPort = this.defaultStartPort;
     for (let i = 0; i < 15; i++) {

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -200,7 +200,7 @@ export class ProjectService {
     baseConfig: ProjectBaseConfig,
     advancedConfig: ProjectAdvancedConfig,
   ): Promise<TemplateType> {
-    const port = await this.portService.getAvailablePort();
+    const port = this.portService.getAvailablePort();
     const servicePort = getServicePort(project.queryEndpoint) ?? port;
     const mmrStoreType = await this.getMmrStoreType(project.id);
     const projectID = projectId(project.id);

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -200,8 +200,7 @@ export class ProjectService {
     baseConfig: ProjectBaseConfig,
     advancedConfig: ProjectAdvancedConfig,
   ): Promise<TemplateType> {
-    const port = this.portService.getAvailablePort();
-    const servicePort = getServicePort(project.queryEndpoint) ?? port;
+    const servicePort = this.portService.getAvailablePort();
     const mmrStoreType = await this.getMmrStoreType(project.id);
     const projectID = projectId(project.id);
 

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -19,7 +19,7 @@ export function projectId(cid: string): string {
 
 export function getServicePort(queryEndpoint: string): number | undefined {
   const port = queryEndpoint ? queryEndpoint.split(':')[2] : undefined;
-  return port ? Number(port) : undefined;
+  return !isNaN(Number(port)) ? Number(port) : undefined;
 }
 
 export function nodeEndpoint(cid: string, port: number): string {

--- a/src/utils/docker.ts
+++ b/src/utils/docker.ts
@@ -18,7 +18,8 @@ export function projectId(cid: string): string {
 }
 
 export function getServicePort(queryEndpoint: string): number | undefined {
-  return queryEndpoint ? Number(queryEndpoint.split(':')[2]) : undefined;
+  const port = queryEndpoint ? queryEndpoint.split(':')[2] : undefined;
+  return port ? Number(port) : undefined;
 }
 
 export function nodeEndpoint(cid: string, port: number): string {

--- a/src/utils/template.yml
+++ b/src/utils/template.yml
@@ -44,7 +44,7 @@ services:
   query_{{projectID}}:
     image: onfinality/subql-query:{{queryVersion}}
     container_name: query_{{projectID}}
-    ports:
+    expose:
       - {{servicePort}}
     depends_on:
       "node_{{projectID}}":

--- a/src/utils/template.yml
+++ b/src/utils/template.yml
@@ -45,7 +45,7 @@ services:
     image: onfinality/subql-query:{{queryVersion}}
     container_name: query_{{projectID}}
     ports:
-      - {{servicePort}}:{{servicePort}}
+      - {{servicePort}}
     depends_on:
       "node_{{projectID}}":
         condition: service_healthy

--- a/src/utils/template.yml
+++ b/src/utils/template.yml
@@ -6,6 +6,8 @@ services:
     container_name: node_{{projectID}}
     restart: always
     cpus: {{cpu}}
+    expose:
+      - {{servicePort}}
     environment:
       DB_USER: {{postgres.user}}
       DB_PASS: {{postgres.pass}}


### PR DESCRIPTION
## Changes

- Return fix port number: `3100` for all the project containers
- Change query port configuration from `ports` to `expose` to avoid docker mapping a port on the host

## Updates for the runninbg docker container

```
CONTAINER ID   IMAGE                                   COMMAND                  CREATED          STATUS                    PORTS                                                                          NAMES
11b0f94abb3   onfinality/subql-query:v2.0.0           "/sbin/tini -- /usr/…"   5 minutes ago    Up 4 minutes              3100/tcp                                                                       query_qmv6sbipytdujcq
b3f146a3647c   onfinality/subql-node-ethereum:v2.8.0   "/sbin/tini -- /usr/…"   5 minutes ago    Up 5 minutes (healthy)                                                                                   node_qmv6sbipytdujcq
59ed8c973c00   onfinality/subql-query:v2.0.0           "/sbin/tini -- /usr/…"   10 minutes ago   Up 9 minutes              3100/tcp                                                                       query_qmqtmshojeyucxk
8057d01eb3c1   onfinality/subql-node:v2.8.0            "/sbin/tini -- /usr/…"   10 minutes ago   Up 10 minutes (healthy)                                                                                  node_qmqtmshojeyucxk
```