### PR TITLE
Remove deprecated options

### DIFF
--- a/apps/indexer-coordinator/src/configure/configure.module.ts
+++ b/apps/indexer-coordinator/src/configure/configure.module.ts
@@ -20,7 +20,6 @@ export interface IConfig {
   readonly port: number;
   readonly postgres: Postgres;
   readonly debug: boolean;
-  readonly dev: boolean;
   readonly secret: string;
   readonly startPort: number;
   readonly dockerNetwork: string;
@@ -41,7 +40,6 @@ export class Config implements IConfig {
       wsEndpoint: argv['ws-endpoint'],
       port: argv['port'],
       debug: argv['debug'],
-      dev: argv['dev'],
       secret: argv['secret-key'],
       startPort: argv['start-port'],
       dockerNetwork: argv['docker-network'],

--- a/apps/indexer-coordinator/src/configure/configure.module.ts
+++ b/apps/indexer-coordinator/src/configure/configure.module.ts
@@ -71,10 +71,6 @@ export class Config implements IConfig {
     return this._config.debug;
   }
 
-  get dev(): boolean {
-    return this._config.dev;
-  }
-
   get secret(): string {
     return this._config.secret;
   }

--- a/apps/indexer-coordinator/src/yargs.ts
+++ b/apps/indexer-coordinator/src/yargs.ts
@@ -36,13 +36,6 @@ function getYargsOption() {
       default: 'https://polygon-rpc.com',
       group: Groups.coordinator,
     },
-    'start-block': {
-      type: 'number',
-      describe: 'Specify the block hight start sync',
-      demandOption: true,
-      default: 33168664,
-      group: Groups.coordinator,
-    },
     ipfs: {
       type: 'string',
       describe: 'Specify ipfs endpoint for this network',
@@ -58,12 +51,6 @@ function getYargsOption() {
     debug: {
       type: 'boolean',
       describe: 'Enable debug mode',
-      default: false,
-      group: Groups.coordinator,
-    },
-    dev: {
-      type: 'boolean',
-      describe: 'Enable dev mode',
       default: false,
       group: Groups.coordinator,
     },


### PR DESCRIPTION
## Changes

- Remove `dev` and `start-block` from yargs options