### PR TITLE
Add rate limit to metadata

### DIFF
--- a/apps/indexer-proxy/proxy/src/project.rs
+++ b/apps/indexer-proxy/proxy/src/project.rs
@@ -115,6 +115,7 @@ impl Project {
             "controller": format!("{:?}", controller_address),
             "deploymentId": self.id,
             "timestamp": timestamp,
+            "rateLimit": self.rate_limit.unwrap_or(1000),
             "signature": sign.to_string(),
         });
 


### PR DESCRIPTION
add rate limit to metadata, if not set, default will show 1000 (only for show, not the real, real is no limit), The number of requests per second is large enough to reduce programming complexity.