### PR TITLE
fix in the TODO.md

### DIFF
--- a/apps/indexer-admin/TODO.md
+++ b/apps/indexer-admin/TODO.md
@@ -15,7 +15,7 @@
 
 - Part 2 for the query and contract
 
-  - [ ] Move the relative codes to togather.
+  - [ ] Move the relative codes to together.
   - [ ] Wrap ContractSDK.
         ...
 


### PR DESCRIPTION
## Fix Typo in `TODO.md`

### Changes
- Corrected a typo: `togather` → `together`.
