### PR TITLE
[SKIP CI]docs: fix typos

### DIFF
--- a/apps/indexer-admin/src/components/errorPlaceholder/index.tsx
+++ b/apps/indexer-admin/src/components/errorPlaceholder/index.tsx
@@ -33,7 +33,7 @@ const ErrorPlaceholder: FC<IProps> = (props) => {
         Oops! Can&apos;t connect to coordinator
       </Typography>
       <Typography type="secondary" style={{ textAlign: 'center' }}>
-        It looks like the coordinator service is temporarily unavaiable
+        It looks like the coordinator service is temporarily unavailable
         <span>, please</span>
         <br />
         <span>check your coordinator service or let us know in </span>

--- a/apps/indexer-coordinator/src/monitor.controller.ts
+++ b/apps/indexer-coordinator/src/monitor.controller.ts
@@ -18,9 +18,9 @@ class Proxy {
   peer: string;
   // peer address in the p2p network
   addr: string;
-  // the number of actived agreements
+  // the number of active agreements
   agreement: number;
-  // the number of actived state channels
+  // the number of active state channels
   channel: number;
 }
 


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `unavaiable` → `unavailable`
  - `actived` → `active`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.