### PR TITLE
Fixing healtheck for node service

### DIFF
--- a/apps/indexer-coordinator/src/utils/template.yml
+++ b/apps/indexer-coordinator/src/utils/template.yml
@@ -54,7 +54,7 @@ services:
     healthcheck:
       test: [
           "CMD-SHELL",
-          "wget -qO- http://subquery-node:3000/ready >/dev/null 2>&1"
+          "wget -qO- http://node_{{projectID}}:{{servicePort}}/ready >/dev/null 2>&1"
       ]
       interval: 3s
       timeout: 5s


### PR DESCRIPTION
curl is missing from all fresh subQl images. Absolutely all new projects do not pass healthcheck due to the lack of a module. curl has been replaced with wget, which is always present in images.
